### PR TITLE
user order='lower' for imshow when y is ascending

### DIFF
--- a/plotter/plotter_core.py
+++ b/plotter/plotter_core.py
@@ -284,7 +284,14 @@ class PlotterCore:
                         # not super accurate, off by half pixel
                         self.extent = [np.min(self.x), np.max(self.x), np.min(self.y), np.max(self.y)]
 
-                self.im = self.ax.imshow(arr, extent=self.extent, transform=self.projection, **kwds)
+                if 'origin' not in kwds and self.y is not None and self.y[0] < self.y[-1]:
+                    # y is ascending order, not typical gis raster.
+                    origin = 'lower'
+                else:
+                    origin = 'upper'
+
+                self.im = self.ax.imshow(arr, extent=self.extent, origin =
+                                         origin, transform=self.projection, **kwds)
                 self.mappable = self.im
 
             if self.contour_options is not None:


### PR DESCRIPTION
I used imshow() this week for firstime in long time.  

When I fed a data from hysplit --> con2cdf4 netcdf4 data, i see image flipped upside down.  Strangely, it seems like this happen when imshow() is used, and subsequent set_data seems to fix the problem.

Despite weirdness above, i figured that the problem is related to the fact that somehow this netdf file has y in ascending order, unlike typical raster data.  According to mpl.Axes.imshow() help, i should say it origin='lower' in this case.

This change seems to fix the problem, image shows up with righ orientation for both imshow() and subsequent set_data().

When this imshow capability is used for data from different source, this may resurface if my assumption here is wrong.  So, just revisit this in future as needed.